### PR TITLE
Added multi module lcov analysis support

### DIFF
--- a/javascript-squid/src/main/java/org/sonar/javascript/model/ASTMaker.java
+++ b/javascript-squid/src/main/java/org/sonar/javascript/model/ASTMaker.java
@@ -240,7 +240,7 @@ public final class ASTMaker {
           if (astNode.getChild(i).is(EcmaScriptGrammar.ARGUMENTS)) {
             result = new TreeImpl.FunctionCallTreeImpl(astNode,
               result,
-              (List<? extends ExpressionTree>) t.getList(astNode.getChild(i))
+              t.getList(astNode.getChild(i))
             );
             i += 1;
           } else if (astNode.getChild(i).is(EcmaScriptPunctuator.LBRACKET)) {
@@ -337,7 +337,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.BlockTreeImpl(astNode,
-          (List<? extends StatementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
+          t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
         );
       }
     }, EcmaScriptGrammar.BLOCK);
@@ -345,7 +345,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.VariableStatementTreeImpl(astNode,
-          (List<VariableDeclarationTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.VARIABLE_DECLARATION_LIST))
+          t.getList(astNode.getFirstChild(EcmaScriptGrammar.VARIABLE_DECLARATION_LIST))
         );
       }
     }, EcmaScriptGrammar.VARIABLE_STATEMENT);
@@ -528,7 +528,7 @@ public final class ASTMaker {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.CaseClauseTreeImpl(astNode,
           null,
-          (List<? extends StatementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
+          t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
         );
       }
     }, EcmaScriptGrammar.DEFAULT_CLAUSE);
@@ -557,7 +557,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.ProgramTreeImpl(astNode,
-          (List<? extends SourceElementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.SOURCE_ELEMENTS))
+          t.getList(astNode.getFirstChild(EcmaScriptGrammar.SOURCE_ELEMENTS))
         );
       }
     }, EcmaScriptGrammar.PROGRAM);

--- a/javascript-squid/src/main/java/org/sonar/javascript/model/ASTMaker.java
+++ b/javascript-squid/src/main/java/org/sonar/javascript/model/ASTMaker.java
@@ -240,7 +240,7 @@ public final class ASTMaker {
           if (astNode.getChild(i).is(EcmaScriptGrammar.ARGUMENTS)) {
             result = new TreeImpl.FunctionCallTreeImpl(astNode,
               result,
-              t.getList(astNode.getChild(i))
+              (List<? extends ExpressionTree>) t.getList(astNode.getChild(i))
             );
             i += 1;
           } else if (astNode.getChild(i).is(EcmaScriptPunctuator.LBRACKET)) {
@@ -337,7 +337,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.BlockTreeImpl(astNode,
-          t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
+          (List<? extends StatementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
         );
       }
     }, EcmaScriptGrammar.BLOCK);
@@ -345,7 +345,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.VariableStatementTreeImpl(astNode,
-          t.getList(astNode.getFirstChild(EcmaScriptGrammar.VARIABLE_DECLARATION_LIST))
+          (List<VariableDeclarationTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.VARIABLE_DECLARATION_LIST))
         );
       }
     }, EcmaScriptGrammar.VARIABLE_STATEMENT);
@@ -528,7 +528,7 @@ public final class ASTMaker {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.CaseClauseTreeImpl(astNode,
           null,
-          t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
+          (List<? extends StatementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.STATEMENT_LIST))
         );
       }
     }, EcmaScriptGrammar.DEFAULT_CLAUSE);
@@ -557,7 +557,7 @@ public final class ASTMaker {
     dispatcher.register(new Maker() {
       public Tree make(AstNode astNode, Trees t) {
         return new TreeImpl.ProgramTreeImpl(astNode,
-          t.getList(astNode.getFirstChild(EcmaScriptGrammar.SOURCE_ELEMENTS))
+          (List<? extends SourceElementTree>) t.getList(astNode.getFirstChild(EcmaScriptGrammar.SOURCE_ELEMENTS))
         );
       }
     }, EcmaScriptGrammar.PROGRAM);

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
@@ -19,6 +19,9 @@
  */
 package org.sonar.plugins.javascript.lcov;
 
+import java.io.File;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,68 +36,81 @@ import org.sonar.api.resources.Project;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 import org.sonar.plugins.javascript.core.JavaScript;
 
-import java.io.File;
-import java.util.Map;
-
 public class LCOVSensor implements Sensor {
 
-  private static final Logger LOG = LoggerFactory.getLogger(LCOVSensor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LCOVSensor.class);
 
-  private final JavaScript javascript;
+    private final JavaScript javascript;
 
-  public LCOVSensor(JavaScript javascript) {
-    this.javascript = javascript;
-  }
-
-  public boolean shouldExecuteOnProject(Project project) {
-    return JavaScript.isEnabled(project)
-      && StringUtils.isNotBlank(javascript.getSettings().getString(JavaScriptPlugin.LCOV_REPORT_PATH));
-  }
-
-  public void analyse(Project project, SensorContext context) {
-    File lcovFile = project.getFileSystem().resolvePath(javascript.getSettings().getString(JavaScriptPlugin.LCOV_REPORT_PATH));
-    if (lcovFile.isFile()) {
-      LCOVParser parser = new LCOVParser(project.getFileSystem());
-      LOG.info("Analysing {}", lcovFile);
-      Map<String, CoverageMeasuresBuilder> coveredFiles = parser.parseFile(lcovFile);
-      analyseCoveredFiles(project, context, coveredFiles);
+    public LCOVSensor(JavaScript javascript) {
+        this.javascript = javascript;
     }
-  }
 
-  protected void analyseCoveredFiles(Project project, SensorContext context, Map<String, CoverageMeasuresBuilder> coveredFiles) {
-    for (InputFile inputFile : project.getFileSystem().mainFiles(JavaScript.KEY)) {
-      try {
-        CoverageMeasuresBuilder fileCoverage = coveredFiles.get(inputFile.getFile().getAbsolutePath());
-        org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(inputFile.getFile(), project);
-        PropertiesBuilder<Integer, Integer> lineHitsData = new PropertiesBuilder<Integer, Integer>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
+    public boolean shouldExecuteOnProject(Project project) {
+        return JavaScript.isEnabled(project) && projectIsJavaScriptModule(project);
+    }
 
-        if (fileCoverage != null) {
-          for (Measure measure : fileCoverage.createMeasures()) {
-            context.saveMeasure(resource, measure);
-          }
-        } else {
-
-          // colour all lines as not executed
-          for (int x = 1; x < context.getMeasure(resource, CoreMetrics.LINES).getIntValue(); x++) {
-            lineHitsData.add(x, 0);
-          }
-
-          // use non comment lines of code for coverage calculation
-          Measure ncloc = context.getMeasure(resource, CoreMetrics.NCLOC);
-          context.saveMeasure(resource, lineHitsData.build());
-          context.saveMeasure(resource, CoreMetrics.LINES_TO_COVER, ncloc.getValue());
-          context.saveMeasure(resource, CoreMetrics.UNCOVERED_LINES, ncloc.getValue());
+    private boolean projectIsJavaScriptModule(Project project) {
+        boolean result = false;
+        Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
+        if (property != null) {
+            result = StringUtils.isNotBlank(property.toString());
         }
 
-      } catch (Exception e) {
-        LOG.error("Problem while calculating coverage for " + inputFile.getFile().getAbsolutePath(), e);
-      }
+        return result;
     }
-  }
 
-  @Override
-  public String toString() {
-    return getClass().getSimpleName();
-  }
+    public void analyse(Project project, SensorContext context) {
+        Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
+
+        if (property != null) {
+            String path = property.toString();
+
+            File lcovFile = project.getFileSystem().resolvePath(path);
+            if (lcovFile != null && lcovFile.isFile()) {
+                LCOVParser parser = new LCOVParser(project.getFileSystem());
+                LOG.info("Analysing {}", lcovFile);
+                Map<String, CoverageMeasuresBuilder> coveredFiles = parser.parseFile(lcovFile);
+                analyseCoveredFiles(project, context, coveredFiles);
+            }
+        }
+    }
+
+    protected void analyseCoveredFiles(Project project, SensorContext context, Map<String, CoverageMeasuresBuilder> coveredFiles) {
+        for (InputFile inputFile : project.getFileSystem().mainFiles(JavaScript.KEY)) {
+            try {
+                CoverageMeasuresBuilder fileCoverage = coveredFiles.get(inputFile.getFile().getAbsolutePath());
+                org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(inputFile.getFile(), project);
+                PropertiesBuilder<Integer, Integer> lineHitsData =
+                        new PropertiesBuilder<Integer, Integer>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
+
+                if (fileCoverage != null) {
+                    for (Measure measure : fileCoverage.createMeasures()) {
+                        context.saveMeasure(resource, measure);
+                    }
+                } else {
+
+                    // colour all lines as not executed
+                    for (int x = 1; x < context.getMeasure(resource, CoreMetrics.LINES).getIntValue(); x++) {
+                        lineHitsData.add(x, 0);
+                    }
+
+                    // use non comment lines of code for coverage calculation
+                    Measure ncloc = context.getMeasure(resource, CoreMetrics.NCLOC);
+                    context.saveMeasure(resource, lineHitsData.build());
+                    context.saveMeasure(resource, CoreMetrics.LINES_TO_COVER, ncloc.getValue());
+                    context.saveMeasure(resource, CoreMetrics.UNCOVERED_LINES, ncloc.getValue());
+                }
+
+            } catch (Exception e) {
+                LOG.error("Problem while calculating coverage for " + inputFile.getFile().getAbsolutePath(), e);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.javascript.lcov;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.Sensor;
@@ -51,7 +52,7 @@ public class LCOVSensor implements Sensor {
   
   public boolean projectHasLCOVReportPath(Project project) {
     Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
-    return property != null;    
+    return property != null && StringUtils.isNotBlank(property.toString());    
   }
 
   public void analyse(Project project, SensorContext context) {

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
@@ -19,9 +19,6 @@
  */
 package org.sonar.plugins.javascript.lcov;
 
-import java.io.File;
-import java.util.Map;
-
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,81 +33,83 @@ import org.sonar.api.resources.Project;
 import org.sonar.plugins.javascript.JavaScriptPlugin;
 import org.sonar.plugins.javascript.core.JavaScript;
 
+import java.io.File;
+import java.util.Map;
+
 public class LCOVSensor implements Sensor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LCOVSensor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LCOVSensor.class);
 
-    private final JavaScript javascript;
+  private final JavaScript javascript;
 
-    public LCOVSensor(JavaScript javascript) {
-        this.javascript = javascript;
+  public LCOVSensor(JavaScript javascript) {
+    this.javascript = javascript;
+  }
+
+  public boolean shouldExecuteOnProject(Project project) {
+    return JavaScript.isEnabled(project) && projectIsJavaScriptModule(project);
+  }
+  
+  public boolean projectIsJavaScriptModule(Project project) {
+    boolean result = false;
+    Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
+    if (property != null) {
+      result = StringUtils.isNotBlank(property.toString());
     }
+    
+    return result;
+  }
 
-    public boolean shouldExecuteOnProject(Project project) {
-        return JavaScript.isEnabled(project) && projectIsJavaScriptModule(project);
+  public void analyse(Project project, SensorContext context) {
+    Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
+    
+    if (property != null) {
+      String path = property.toString();
+      
+      File lcovFile = project.getFileSystem().resolvePath(path);
+      if (lcovFile.isFile()) {
+        LCOVParser parser = new LCOVParser(project.getFileSystem());
+        LOG.info("Analysing {}", lcovFile);
+        Map<String, CoverageMeasuresBuilder> coveredFiles = parser.parseFile(lcovFile);
+        analyseCoveredFiles(project, context, coveredFiles);
+      }
     }
+  }
 
-    private boolean projectIsJavaScriptModule(Project project) {
-        boolean result = false;
-        Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
-        if (property != null) {
-            result = StringUtils.isNotBlank(property.toString());
+  protected void analyseCoveredFiles(Project project, SensorContext context, Map<String, CoverageMeasuresBuilder> coveredFiles) {
+    for (InputFile inputFile : project.getFileSystem().mainFiles(JavaScript.KEY)) {
+      try {
+        CoverageMeasuresBuilder fileCoverage = coveredFiles.get(inputFile.getFile().getAbsolutePath());
+        org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(inputFile.getFile(), project);
+        PropertiesBuilder<Integer, Integer> lineHitsData = new PropertiesBuilder<Integer, Integer>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
+
+        if (fileCoverage != null) {
+          for (Measure measure : fileCoverage.createMeasures()) {
+            context.saveMeasure(resource, measure);
+          }
+        } else {
+
+          // colour all lines as not executed
+          for (int x = 1; x < context.getMeasure(resource, CoreMetrics.LINES).getIntValue(); x++) {
+            lineHitsData.add(x, 0);
+          }
+
+          // use non comment lines of code for coverage calculation
+          Measure ncloc = context.getMeasure(resource, CoreMetrics.NCLOC);
+          context.saveMeasure(resource, lineHitsData.build());
+          context.saveMeasure(resource, CoreMetrics.LINES_TO_COVER, ncloc.getValue());
+          context.saveMeasure(resource, CoreMetrics.UNCOVERED_LINES, ncloc.getValue());
         }
 
-        return result;
+      } catch (Exception e) {
+        LOG.error("Problem while calculating coverage for " + inputFile.getFile().getAbsolutePath(), e);
+      }
     }
+  }
 
-    public void analyse(Project project, SensorContext context) {
-        Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
-
-        if (property != null) {
-            String path = property.toString();
-
-            File lcovFile = project.getFileSystem().resolvePath(path);
-            if (lcovFile != null && lcovFile.isFile()) {
-                LCOVParser parser = new LCOVParser(project.getFileSystem());
-                LOG.info("Analysing {}", lcovFile);
-                Map<String, CoverageMeasuresBuilder> coveredFiles = parser.parseFile(lcovFile);
-                analyseCoveredFiles(project, context, coveredFiles);
-            }
-        }
-    }
-
-    protected void analyseCoveredFiles(Project project, SensorContext context, Map<String, CoverageMeasuresBuilder> coveredFiles) {
-        for (InputFile inputFile : project.getFileSystem().mainFiles(JavaScript.KEY)) {
-            try {
-                CoverageMeasuresBuilder fileCoverage = coveredFiles.get(inputFile.getFile().getAbsolutePath());
-                org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(inputFile.getFile(), project);
-                PropertiesBuilder<Integer, Integer> lineHitsData =
-                        new PropertiesBuilder<Integer, Integer>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
-
-                if (fileCoverage != null) {
-                    for (Measure measure : fileCoverage.createMeasures()) {
-                        context.saveMeasure(resource, measure);
-                    }
-                } else {
-
-                    // colour all lines as not executed
-                    for (int x = 1; x < context.getMeasure(resource, CoreMetrics.LINES).getIntValue(); x++) {
-                        lineHitsData.add(x, 0);
-                    }
-
-                    // use non comment lines of code for coverage calculation
-                    Measure ncloc = context.getMeasure(resource, CoreMetrics.NCLOC);
-                    context.saveMeasure(resource, lineHitsData.build());
-                    context.saveMeasure(resource, CoreMetrics.LINES_TO_COVER, ncloc.getValue());
-                    context.saveMeasure(resource, CoreMetrics.UNCOVERED_LINES, ncloc.getValue());
-                }
-
-            } catch (Exception e) {
-                LOG.error("Problem while calculating coverage for " + inputFile.getFile().getAbsolutePath(), e);
-            }
-        }
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName();
-    }
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
 
 }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/LCOVSensor.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.javascript.lcov;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.Sensor;
@@ -47,17 +46,12 @@ public class LCOVSensor implements Sensor {
   }
 
   public boolean shouldExecuteOnProject(Project project) {
-    return JavaScript.isEnabled(project) && projectIsJavaScriptModule(project);
+    return JavaScript.isEnabled(project) && projectHasLCOVReportPath(project);
   }
   
-  public boolean projectIsJavaScriptModule(Project project) {
-    boolean result = false;
+  public boolean projectHasLCOVReportPath(Project project) {
     Object property = project.getProperty(JavaScriptPlugin.LCOV_REPORT_PATH);
-    if (property != null) {
-      result = StringUtils.isNotBlank(property.toString());
-    }
-    
-    return result;
+    return property != null;    
   }
 
   public void analyse(Project project, SensorContext context) {

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/LCOVSensorTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/lcov/LCOVSensorTest.java
@@ -76,7 +76,7 @@ public class LCOVSensorTest {
     assertThat(sensor.shouldExecuteOnProject(project)).isTrue();
 
     // no path to report -> do not execute
-    project.setBranch("");
+    settings.setProperty(JavaScriptPlugin.LCOV_REPORT_PATH, "");
     assertThat(sensor.shouldExecuteOnProject(project)).isFalse();
   }
 
@@ -136,8 +136,6 @@ public class LCOVSensorTest {
 
   private Project mockProject() {
     return new Project("dummy") {
-      private Object property = "jsTestDriver.conf-coverage.dat";
-
       @Override
       public ProjectFileSystem getFileSystem() {
         return fileSystem;
@@ -155,14 +153,7 @@ public class LCOVSensorTest {
       
       @Override
       public Object getProperty(String key) {
-        return property;
-      }
-
-      @Override
-      public Project setBranch(String property) {
-        this.property = property;
-
-        return this;
+        return settings.getString(key);
       }
     };
   }


### PR DESCRIPTION
The JavaScript Sonar plugin didn't support LCOV analysis in multi module projects, when analysing a multi module project, only the root POM would be checked for a LCOV report path, while the report path was defined in a sub module (or in multiple sub modules). To support this set-up the LCOVSensor had to adjusted. Instead of the root project settings it now uses the project specific properties.

The ASTMaker class had some errors, 5 casts were removed to resolve them.