### PR TITLE
Factorize orchestrator version and exclude oracle jdbc dependency from orchestrator which is not needed

### DIFF
--- a/its/performancing/pom.xml
+++ b/its/performancing/pom.xml
@@ -18,8 +18,14 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.5</version>
+      <version>${orchestrator.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle</groupId>
+          <artifactId>ojdbc6</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -20,7 +20,13 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.7</version>
+      <version>${orchestrator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle</groupId>
+          <artifactId>ojdbc6</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -25,8 +25,14 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.7</version>
+      <version>${orchestrator.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle</groupId>
+          <artifactId>ojdbc6</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/its/type-inference/tests/pom.xml
+++ b/its/type-inference/tests/pom.xml
@@ -20,7 +20,13 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.7</version>
+      <version>${orchestrator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle</groupId>
+          <artifactId>ojdbc6</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 
     <sonar.version>4.5.2</sonar.version>
     <sslr.version>1.21</sslr.version>
+    <orchestrator.version>3.8</orchestrator.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Build fails if oracle jdbc is not present.