### PR TITLE
Prevent IndexOutOfBoundsException on analysis

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/AbstractFunctionSizeCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/AbstractFunctionSizeCheck.java
@@ -126,7 +126,9 @@ public abstract class AbstractFunctionSizeCheck extends SubscriptionVisitorCheck
   private void checkArrayLiteral(Tree secondParameter) {
     if (secondParameter.is(Kind.ARRAY_LITERAL)) {
       List<ExpressionTree> elements = ((ArrayLiteralTree) secondParameter).elements();
-      checkSimpleArgument(elements.get(elements.size() - 1));
+      if (!elements.isEmpty()) {
+        checkSimpleArgument(elements.get(elements.size() - 1));
+      }
     }
   }
 

--- a/javascript-checks/src/test/resources/checks/tooManyLinesInFunction.js
+++ b/javascript-checks/src/test/resources/checks/tooManyLinesInFunction.js
@@ -125,3 +125,5 @@ function foo() {  // NOK
 
 
 }
+
+moduleX.value("name", []);  // OK


### PR DESCRIPTION
If a function is called on an Angular module, and the last parameter of
that function is an empty array, analysis previously failed with an
IndexOutOfBoundsException.