### PR TITLE
Increase expectations for Performance IT

### DIFF
--- a/its/performancing/src/test/java/JavaScriptPerformanceTest.java
+++ b/its/performancing/src/test/java/JavaScriptPerformanceTest.java
@@ -47,12 +47,12 @@ public class JavaScriptPerformanceTest {
 
   @Test
   public void test_parsing_performance() throws IOException {
-    test_performance("parsing-project", "no-rules", false, 151.0);
+    test_performance("parsing-project", "no-rules", false, 153.0);
   }
 
   @Test
   public void test_symbolic_engine_performance() throws IOException {
-    test_performance("se-project", "se-profile", true, 185.0);
+    test_performance("se-project", "se-profile", true, 194.0);
   }
 
   private static void test_performance(String projectKey, String profile, boolean shouldRaiseAnyIssue, double expectedTime) throws IOException {


### PR DESCRIPTION
Since we've started parsing Flow, parsing time slightly increased (around 2-3 seconds more).
Also it looks like when in previous  sprint (for 3.1) we added new files for Vue and new metric computation, parsing time increased, and expectation was updated only for parsing test (see commit 7df6fc71b6f481dce2739843db3e2e8e5a908efc mistakenly naming this change only for new metric). That's why update of SE Perf test is bigger.